### PR TITLE
enable a discard logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ Run the application and restart on file modifications.
 beagle run go run main.go
 ```
 
+### Import Beagle
+
+package db logs to stdout, if this is unwanted this can be switched off. At start call `db.DiscardLogging()` or set the environment variable `BEAGLE_NOLOG`.

--- a/db/db.go
+++ b/db/db.go
@@ -16,6 +16,8 @@ package db
 import (
 	"context"
 	"database/sql"
+	"io"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -30,6 +32,22 @@ import (
 )
 
 var log = logging.MustGetLogger("go.dutchsec.com/beagle/db")
+
+var once sync.Once
+
+func init() {
+	_, ok := os.LookupEnv("BEAGLE_NOLOG")
+	if ok {
+		DiscardLogging()
+	}
+}
+
+func DiscardLogging() {
+	once.Do(func() {
+		discard := logging.NewLogBackend(io.Discard, "", 0)
+		logging.SetBackend(discard)
+	})
+}
 
 // Newerer TODO: NEEDS COMMENT INFO
 type Newerer interface {


### PR DESCRIPTION
Created the option to show no log output from db package, with a call to `DiscardLogging()` or set an environment variable `BEAGLE_NOLOG`